### PR TITLE
Add hashing function

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
 							</li>
 							<li><a href="#verify" data-toggle="tab"><span class="glyphicon glyphicon-ok"></span> Verify</a></li>
 							<li><a href="#sign" data-toggle="tab"><span class="glyphicon glyphicon-pencil"></span> Sign</a></li>
+							<li><a href="#hash" data-toggle="tab"><span class="glyphicon glyphicon-globe"></span> Hash</a></li>
 							<li><a href="#broadcast" data-toggle="tab"><span class="glyphicon glyphicon-globe"></span> Broadcast</a></li>
 							<li><a href="#wallet" data-toggle="tab"><span class="glyphicon glyphicon-briefcase"></span> Wallet</a></li>
 							<li><a href="#about" data-toggle="tab"><span class="glyphicon glyphicon-info-sign"></span> About</a></li>
@@ -1294,6 +1295,17 @@
 						</div>
 
 						<input type="button" value="Submit" class="btn btn-primary" id="signBtn">
+						<br>
+					</div>
+
+					<div class="tab-pane tab-content" id="hash">
+						<h2>Create hash <small>using the Double-SHA256 hashing algorithm</small></h2>
+						<p>Enter your text to be hashed</p>
+						<textarea class="form-control" style="height:125px" id="textToHash"></textarea>
+						<br>
+						<div id="textToHashStatus" class="alert">Status
+						</div>
+						<input type="button" value="Submit" id="doublehashSubmitBtn" class="btn btn-primary">
 						<br>
 					</div>
 

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -1344,6 +1344,42 @@ $(document).ready(function() {
 
 
 
+	/* hash script code */
+
+	function bytesToString(a){
+		for (var d=[],b=0;b<a.length;b++)
+			d.push(String.fromCharCode(a[b]));
+		return d.join("")
+	};
+	function msg_numToVarInt(a){
+		if (253 > a) return [a];
+		if (65535 >= a) return [253, a&255, a>>>8];
+		throw"message too large";
+	}
+	function msg_bytes(a){
+		a = Crypto.charenc.UTF8.stringToBytes(a);
+		return msg_numToVarInt(a.length).concat(a);
+	}
+	function msg_digest(a){
+		a = msg_bytes("ION Signed Message:\n").concat(msg_bytes(a));
+		a = bytesToString(msg_bytes(a));
+		return Crypto.SHA256(Crypto.SHA256(a,{asBytes:true}),{asBytes:false});
+	}
+	function reverseByteArray(arrayIn) {
+		var result = [];
+		for (var i = arrayIn.length-1; i >= 0; i--) {
+		  result.push(arrayIn[i]);
+		}
+		return result;
+	}
+	function doubleHash(a) {
+		return Crypto.SHA256(Crypto.SHA256(a,{asBytes:true}),{asBytes:true});
+	}
+	$("#doublehashSubmitBtn").click(function(){
+		$("#textToHashStatus").addClass('alert-success').removeClass('alert-danger');
+		var hash = doubleHash(Crypto.charenc.UTF8.stringToBytes($("#textToHash").val()));
+		$("#textToHashStatus").html('Hash: '+Crypto.util.bytesToHex(reverseByteArray(hash)));
+	});
 
 	/* verify script code */
 
@@ -1671,6 +1707,13 @@ $(document).ready(function() {
 			}
 		}
 		return r;
+	}
+
+	var _getDoublehash = _get("hash");
+	if(_getDoublehash[0]){
+		$("#textToHash").val(_getDoublehash[0]);
+		$("#doublehashSubmitBtn").click();
+		window.location.hash = "#hash";
 	}
 
 	var _getBroadcast = _get("broadcast");


### PR DESCRIPTION
ION's Atomic Token Protocol (ATP) includes the option to refer to an external specification file from the token configuration transaction.

The token configuration transaction then includes a link to the document and the document's hash. This hash is a Double-SHA256 hash, as is customary in the bitcoin protocol.

To support easy generation of this hash, this commit extends the ION Browser Wallet with the function to generate this hash.

(Possibly, the browser wallet can also be extended with a Sign Message feature, similar to the feature already present in the core node; helper-functions for signing have already been included in this commit.)